### PR TITLE
Added option to disable token replacement

### DIFF
--- a/src/main/java/com/hpe/cloudfoundryjenkins/CloudFoundryPushPublisher.java
+++ b/src/main/java/com/hpe/cloudfoundryjenkins/CloudFoundryPushPublisher.java
@@ -174,7 +174,7 @@ public class CloudFoundryPushPublisher extends Recorder {
                 for (Map<String, Object> appInfo : appList) {
                     allDeploymentInfo.add(
                             new DeploymentInfo(build, listener, listener.getLogger(),
-                                    appInfo, jenkinsBuildName, domain, manifestChoice.manifestFile));
+                                    appInfo, jenkinsBuildName, domain, manifestChoice.manifestFile, manifestChoice.manifestDisableTokenReplacement));
                 }
             } else {
                 // Read Jenkins configuration
@@ -505,6 +505,7 @@ public class CloudFoundryPushPublisher extends Recorder {
 
         // Variable of the choice "manifestFile". Will be null if 'value' is "jenkinsConfig".
         public final String manifestFile;
+        public final boolean manifestDisableTokenReplacement;
 
         // Variables of the choice "jenkinsConfig". Will all be null (or 0 or false) if 'value' is "manifestFile".
         public final String appName;
@@ -523,7 +524,7 @@ public class CloudFoundryPushPublisher extends Recorder {
 
 
         @DataBoundConstructor
-        public ManifestChoice(String value, String manifestFile,
+        public ManifestChoice(String value, String manifestFile, boolean manifestDisableTokenReplacement,
                               String appName, int memory, String hostname, int instances, int timeout, boolean noRoute,
                               String appPath, String buildpack, String stack, String command, String domain,
                               List<EnvironmentVariable> envVars, List<ServiceName> servicesNames) {
@@ -537,6 +538,8 @@ public class CloudFoundryPushPublisher extends Recorder {
             } else {
                 this.manifestFile = manifestFile;
             }
+
+            this.manifestDisableTokenReplacement = manifestDisableTokenReplacement;
 
             this.appName = appName;
             this.memory = memory;
@@ -558,7 +561,7 @@ public class CloudFoundryPushPublisher extends Recorder {
          * This is mostly for easier unit tests.
          */
         public static ManifestChoice defaultManifestFileConfig() {
-            return new ManifestChoice("manifestFile", DEFAULT_MANIFEST_PATH,
+            return new ManifestChoice("manifestFile", DEFAULT_MANIFEST_PATH, false,
                     null, 0, null, 0, 0, false, null, null, null, null, null, null, null);
         }
     }

--- a/src/main/java/com/hpe/cloudfoundryjenkins/DeploymentInfo.java
+++ b/src/main/java/com/hpe/cloudfoundryjenkins/DeploymentInfo.java
@@ -50,11 +50,13 @@ public class DeploymentInfo {
      * Takes an appInfo Map that is created from a ManifestReader.
      */
     public DeploymentInfo(AbstractBuild build, TaskListener listener, PrintStream logger, Map<String, Object> appInfo,
-                          String jenkinsBuildName, String defaultDomain, String manifestPath)
+                          String jenkinsBuildName, String defaultDomain, String manifestPath, boolean disableManifestTokens)
             throws IOException, ManifestParsingException, InterruptedException, MacroEvaluationException {
 
         readManifestFile(logger, appInfo, jenkinsBuildName, defaultDomain, manifestPath);
-        expandTokenMacros(build, listener);
+        if (!disableManifestTokens) {
+            expandTokenMacros(build, listener);
+        }
     }
 
     /**

--- a/src/main/java/com/hpe/cloudfoundryjenkins/DeploymentInfo.java
+++ b/src/main/java/com/hpe/cloudfoundryjenkins/DeploymentInfo.java
@@ -67,7 +67,9 @@ public class DeploymentInfo {
             throws IOException, ManifestParsingException, InterruptedException, MacroEvaluationException {
 
         readOptionalJenkinsConfig(logger, optionalJenkinsConfig, jenkinsBuildName, defaultDomain);
-        expandTokenMacros(build, listener);
+        if (!optionalJenkinsConfig.manifestDisableTokenReplacement) {
+            expandTokenMacros(build, listener);
+        }
     }
 
     /**

--- a/src/main/resources/com/hpe/cloudfoundryjenkins/CloudFoundryPushPublisher/config.jelly
+++ b/src/main/resources/com/hpe/cloudfoundryjenkins/CloudFoundryPushPublisher/config.jelly
@@ -51,6 +51,9 @@
     <f:entry title="Manifest file" field="manifestFile">
       <f:textbox value="${instance.manifestChoice.manifestFile}" default="manifest.yml"/>
     </f:entry>
+    <f:entry title="Disable Token Replacement" field="manifestDisableTokenReplacement">
+      <f:checkbox checked="${instance.manifestChoice.manifestDisableTokenReplacement}" default="false" />
+    </f:entry>
   </f:radioBlock>
 
   <f:radioBlock title="Enter configuration in Jenkins" name="manifestChoice" value="jenkinsConfig"

--- a/src/main/resources/com/hpe/cloudfoundryjenkins/CloudFoundryPushPublisher/help-manifestDisableTokenReplacement.jelly
+++ b/src/main/resources/com/hpe/cloudfoundryjenkins/CloudFoundryPushPublisher/help-manifestDisableTokenReplacement.jelly
@@ -1,0 +1,3 @@
+<div>
+    Disable token replacement in specified manifest file.
+</div>

--- a/src/test/java/com/hpe/cloudfoundryjenkins/DeploymentInfoTest.java
+++ b/src/test/java/com/hpe/cloudfoundryjenkins/DeploymentInfoTest.java
@@ -101,7 +101,7 @@ public class DeploymentInfoTest {
         ManifestReader manifestReader = new ManifestReader(manifestFilePath);
         Map<String, Object> appInfo = manifestReader.getApplicationInfo();
         DeploymentInfo deploymentInfo =
-                new DeploymentInfo(build, listener, System.out, appInfo, "jenkins-build-name", "domain-name", "");
+                new DeploymentInfo(build, listener, System.out, appInfo, "jenkins-build-name", "domain-name", "", false);
 
         assertEquals("test-build", deploymentInfo.getAppName());
     }
@@ -117,7 +117,7 @@ public class DeploymentInfoTest {
         ManifestReader manifestReader = new ManifestReader(manifestFilePath);
         Map<String, Object> appInfo = manifestReader.getApplicationInfo();
         DeploymentInfo deploymentInfo =
-                new DeploymentInfo(build, listener, System.out, appInfo, "jenkins-build-name", "domain-name", "");
+                new DeploymentInfo(build, listener, System.out, appInfo, "jenkins-build-name", "domain-name", "", false);
 
         assertEquals("test-build", deploymentInfo.getAppName());
         Map<String, String> expectedEnvs = new HashMap<String, String>();
@@ -136,7 +136,7 @@ public class DeploymentInfoTest {
         services.add(new CloudFoundryPushPublisher.ServiceName("service_name_two"));
         services.add(new CloudFoundryPushPublisher.ServiceName("service_name_three"));
         CloudFoundryPushPublisher.ManifestChoice jenkinsManifest =
-                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, "hello-java", 512, "testhost", 4, 42, true,
+                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, false, "hello-java", 512, "testhost", 4, 42, true,
                         "target/hello-java-1.0.war",
                         "https://github.com/heroku/heroku-buildpack-hello", "customstack",
                         "echo Hello", "testdomain.local", envVars, services);
@@ -171,7 +171,7 @@ public class DeploymentInfoTest {
     @Test
     public void testReadJenkinsConfigDefaultOptions() throws Exception {
         CloudFoundryPushPublisher.ManifestChoice jenkinsManifest =
-                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, "", 0, "", 0, 0, false, "", "", "", "", "", null, null);
+                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, false, "", 0, "", 0, 0, false, "", "", "", "", "", null, null);
         DeploymentInfo deploymentInfo =
                 new DeploymentInfo(System.out, jenkinsManifest, "jenkins-build-name", "domain-name");
 
@@ -198,11 +198,26 @@ public class DeploymentInfoTest {
         build.setDisplayName("test-build");
         TaskListener listener = j.createTaskListener();
         CloudFoundryPushPublisher.ManifestChoice jenkinsManifest =
-                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, "${BUILD_DISPLAY_NAME}",
+                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, false, "${BUILD_DISPLAY_NAME}",
                         0, "", 0, 0, false, "", "", "", "", "", null, null);
         DeploymentInfo deploymentInfo =
                 new DeploymentInfo(build, listener, System.out, jenkinsManifest, "jenkins-build-name", "domain-name");
 
         assertEquals("test-build", deploymentInfo.getAppName());
+    }
+
+    @Test
+    public void testReadJenkinsConfigDisableMacroTokens() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        build.setDisplayName("test-build");
+        TaskListener listener = j.createTaskListener();
+        CloudFoundryPushPublisher.ManifestChoice jenkinsManifest =
+                new CloudFoundryPushPublisher.ManifestChoice("jenkinsConfig", null, true, "${BUILD_DISPLAY_NAME}",
+                        0, "", 0, 0, false, "", "", "", "", "", null, null);
+        DeploymentInfo deploymentInfo =
+                new DeploymentInfo(build, listener, System.out, jenkinsManifest, "jenkins-build-name", "domain-name");
+
+        assertEquals("${BUILD_DISPLAY_NAME}", deploymentInfo.getAppName());
     }
 }


### PR DESCRIPTION
Added the option to disable token replacement in manifest files.  The use case for this is when a manifest file doesn't need token replacement but some of the data in the manifest has tokens that get unintentionally replaced.
